### PR TITLE
Add ignore_on_error option

### DIFF
--- a/spec/gcpc/interceptors/subscriber/decode_interceptor_spec.rb
+++ b/spec/gcpc/interceptors/subscriber/decode_interceptor_spec.rb
@@ -11,23 +11,68 @@ describe Gcpc::Interceptors::Subscriber::DecodeInterceptor do
         interceptors: [
           Gcpc::Interceptors::Subscriber::DecodeInterceptor.new(
             strategy: strategy,
+            logger:   logger,
           )
         ],
       )
     }
     let(:handler) { FakeHandler.new }
     let(:message) { FakeMessage.new(data: data, attributes: {}) }
+    let(:logger) { FakeLogger.new }
 
     context "when strategy is JSONStrategy" do
       let(:strategy) {
         Gcpc::Interceptors::Subscriber::DecodeInterceptor::JSONStrategy.new
       }
-      let(:data) { '{ "id": "33", "name": "Taro" }' }
+      context "when decode is successfull" do
+        let(:data) { '{ "id": "33", "name": "Taro" }' }
 
-      it "decodes data" do
-        expect(handler).to receive(:handle)
-          .with({ "id" => "33", "name" => "Taro" }, {}, message)
-        subject
+        it "decodes data" do
+          expect(handler).to receive(:handle)
+            .with({ "id" => "33", "name" => "Taro" }, {}, message)
+          subject
+        end
+      end
+
+      context "when decode failed" do
+        let(:data) { 'invalid' }
+
+        it "skips handling message" do
+          expect(handler).not_to receive(:handle)
+          expect(message).to receive(:ack!)
+          subject
+          error = logger.messages[:error].first
+          expect(error.inspect).to eq "#<JSON::ParserError: 767: unexpected token at 'invalid'>"
+          info = logger.messages[:info].first
+          expect(info.inspect).to eq "\"Ack a message{data=invalid, attributes={}} because it can't be decoded!\""
+        end
+      end
+    end
+  end
+
+  describe "#initialize" do
+    context "when ignore_on_error is false" do
+      let(:handle_engine) {
+        Gcpc::Subscriber::HandleEngine.new(
+          handler:      handler,
+          interceptors: [
+            Gcpc::Interceptors::Subscriber::DecodeInterceptor.new(
+              strategy:        strategy,
+              logger:          FakeLogger.new,
+              ignore_on_error: false,
+            )
+          ],
+        )
+      }
+      let(:strategy) {
+        Gcpc::Interceptors::Subscriber::DecodeInterceptor::JSONStrategy.new
+      }
+      let(:handler) { FakeHandler.new }
+      let(:message) { FakeMessage.new(data: data, attributes: {}) }
+      let(:data) { 'invalid' }
+
+      it "raises exception when decode failed" do
+        expect { handle_engine.handle(message) }.to raise_error(JSON::ParserError, "767: unexpected token at 'invalid'")
       end
     end
   end

--- a/spec/support/fakes.rb
+++ b/spec/support/fakes.rb
@@ -14,6 +14,14 @@ class FakeMessage
   end
 
   attr_reader :data, :attributes
+
+  def ack!
+    # Do nothing
+  end
+
+  def nack!
+    # Do nothing
+  end
 end
 
 class FakeStore
@@ -31,5 +39,19 @@ class FakeStore
 
   def exists(key)
     @store.has_key?(key)
+  end
+end
+
+class FakeLogger
+  def initialize
+    @messages = {}
+  end
+  attr_reader :messages
+
+  [:debug, :info, :warn, :error, :fatal].each do |level|
+    define_method level do |obj|
+      @messages[level] ||= []
+      @messages[level] << obj
+    end
   end
 end


### PR DESCRIPTION
## Why
In many case when decode failed, we want to ignore the message. 

## What
I added `ignore_on_error` option to `DecodeInterceptor`. If this option is true, message is ignored when decode failed. The default value is true.